### PR TITLE
Remove extraneous from_recformat call

### DIFF
--- a/astropy/io/fits/column.py
+++ b/astropy/io/fits/column.py
@@ -1528,7 +1528,6 @@ class ColDefs(NotifierMixin):
         for idx in range(len(array.dtype)):
             cname = array.dtype.names[idx]
             ftype = array.dtype.fields[cname][0]
-            format = self._col_format_cls.from_recformat(ftype)
 
             if ftype.kind == "O":
                 dtypes = {np.array(array[cname][i]).dtype for i in range(len(array))}


### PR DESCRIPTION
Hi Chiara,
Sorry it took me a long time to get back to this. I was trying to find time to look at the code more in details.
This line should be removed, `from_recformat` is called below in the if/else block. With this your new test is passing (just the warning isn't raised) and I think it should work?