### PR TITLE
PR to PR 17552

### DIFF
--- a/astropy/io/fits/connect.py
+++ b/astropy/io/fits/connect.py
@@ -1,11 +1,11 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-
 import os
 import re
 import warnings
 from copy import deepcopy
 from itertools import pairwise
+from pathlib import Path
 
 import numpy as np
 
@@ -448,7 +448,7 @@ def write_table_fits(input, output, overwrite=False, append=False):
     table_hdu = table_to_hdu(input, character_as_bytes=True)
 
     # Check if output file already exists
-    if isinstance(output, str) and os.path.exists(output):
+    if isinstance(output, (str, Path)) and os.path.exists(output):
         if overwrite:
             os.remove(output)
         elif not append:
@@ -458,7 +458,7 @@ def write_table_fits(input, output, overwrite=False, append=False):
         # verify=False stops it reading and checking the existing file.
         fits_append(output, table_hdu.data, table_hdu.header, verify=False)
     else:
-        table_hdu.writeto(output, overwrite=overwrite)
+        table_hdu.writeto(output)
 
 
 io_registry.register_reader("fits", Table, read_table_fits)

--- a/astropy/io/fits/tests/test_connect.py
+++ b/astropy/io/fits/tests/test_connect.py
@@ -1,6 +1,5 @@
 import gc
 import warnings
-from pathlib import Path
 
 import numpy as np
 import pytest
@@ -66,10 +65,10 @@ class TestSingleTable:
         )
 
     def test_path(self, tmp_path):
-        filename = "temp.fits"
+        filename = tmp_path / "temp.fits"
         t1 = Table(self.data)
-        t1.write(filename, overwrite=True)
-        t1.write(Path(filename), format="fits", overwrite=True)
+        t1.write(filename, format="fits", overwrite=True)
+        t1.write(filename, format="fits", overwrite=True)
 
     def test_simple(self, tmp_path):
         filename = tmp_path / "test_simple.fts"


### PR DESCRIPTION
I think the culprit is the extra checks on L451. If I remove that check, other tests fail. 🥫 🪱 🤪 

Please double check my patch on `connect.py` using your version of the test (without `tmp_path`). But ultimately my suggestion of the test is what I would like to merge if possible and correct. Without using `tmp_path`, "temp.fits" gets written to source dir which is undesirable.

Thanks!